### PR TITLE
Squash commits in existing PR

### DIFF
--- a/prfromtransifex.py
+++ b/prfromtransifex.py
@@ -208,12 +208,17 @@ if __name__ == "__main__":
         debug("Changed files: %s", " ".join(os.linesep.split(changedfiles)))
     
         info("Things changed & force pushing")
-        debug(git["commit", "-m", pr_commit % {'mode': mode,
-                            'minpercent': minpercent,
-                            'langcount': len(files)}]())
-        
-        debug(git["push", "-f", "origin", wr_branch]())
+        commit_msg = pr_commit % {'mode': mode, 'minpercent': minpercent, 'langcount': len(files)}
+        debug(git["commit", "-m", commit_msg]())
+
     
+        if pr:
+            info("PR exists already, squashing changes to commit in PR")
+            debug(git["reset", "--soft", "HEAD~1"])
+            debug(git["commit", "-m", commit_msg])
+
+        debug(git["push", "-f", "origin", wr_branch]())
+        
     if not pr:
         info("No existing PR, creating new one")
         pr = createNewPullRequest(g,


### PR DESCRIPTION
To avoid having to squash the commits manually when merging the respective PR, the bot should automatically squash the new commit into the existing one, if it is contributing to an existing PR.

Note that this is just a crude attempt at how I imagine this could be done. I haven't tested this (as I don't know how I'd go about that) and I only deduced how stuff works by looking at this file alone. Thus there might be some utter nonsense in this change and I'd appreciate someone looking over this carefully ^^

@davidebeatrici This is my attempt of implementing what you suggested the other day :D